### PR TITLE
fix: 修复z-paging依赖的TypeScript类型丢失

### DIFF
--- a/src/pages/tab/list/index.vue
+++ b/src/pages/tab/list/index.vue
@@ -16,7 +16,8 @@
 </template>
 
 <script setup lang="ts">
-const pagingRef = ref<InstanceType<typeof zPaging> | null>(null);
+const pagingRef = ref<ZPagingRef<string> | null>(null);
+
 const dataList = ref<string[]>([]);
 
 const urls: string[] = [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
       "@/*": ["src/*"]
     },
     "resolveJsonModule": true,
-    "types": ["@dcloudio/types", "@uni-helper/uni-app-types", "miniprogram-api-typings", "uview-plus/types"],
+    "types": ["@dcloudio/types", "@uni-helper/uni-app-types", "miniprogram-api-typings", "uview-plus/types", "z-paging/types"],
     "allowJs": true,
     "strict": true,
     "strictNullChecks": true,


### PR DESCRIPTION
修复了z-paging组件类型丢失问题，包括定义z-paging实例

**Before：**
<img width="578" alt="image" src="https://github.com/user-attachments/assets/192951db-4e36-48e2-980e-86cee4ca6cce" />


**After：**

<img width="582" alt="image" src="https://github.com/user-attachments/assets/5b339f79-ea55-44dd-b2c8-dad9686d6605" />
